### PR TITLE
Update Hist.h to declare AdoptErrors()

### DIFF
--- a/CAFAna/Core/Hist.h
+++ b/CAFAna/Core/Hist.h
@@ -36,6 +36,7 @@ namespace ana
     static Hist AdoptSparse(Eigen::SparseVector<double>&& v);
     static Hist AdoptStan(Eigen::ArrayXstan&& v);
     static Hist Adopt(Eigen::ArrayXd&& v);
+    static Hist AdoptErrors(Eigen::ArrayXd&& v, Eigen::ArrayXd&& e);
 
     static Hist FromDirectory(TDirectory* dir);
 


### PR DESCRIPTION
Declare function AdoptErrors(). Will allow the setting of the SumSq array by the user. This is useful for PRISM and is only a minimal extension.