### PR TITLE
Stat error tools prism

### DIFF
--- a/CAFAna/Core/Hist.cxx
+++ b/CAFAna/Core/Hist.cxx
@@ -155,6 +155,16 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  Hist Hist::AdoptErrors(Eigen::ArrayXd&& v, Eigen::ArrayXd&& e)
+  {
+    Hist ret;
+    ret.fType = kDense;
+    ret.fData = std::move(v);
+    ret.fSumSq = std::move(e);
+    return ret;
+  }
+  
+  //----------------------------------------------------------------------
   Hist Hist::FromDirectory(TDirectory* dir)
   {
     Hist ret;
@@ -344,7 +354,7 @@ namespace ana
     fSumSq.resize(0);
     fSqrtErrs = true;
   }
-
+  
   //----------------------------------------------------------------------
   double Hist::GetBinContent(int i) const
   {

--- a/CAFAna/Core/Hist.cxx
+++ b/CAFAna/Core/Hist.cxx
@@ -155,12 +155,13 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
-  Hist Hist::AdoptErrors(Eigen::ArrayXd&& v, Eigen::ArrayXd&& e)
+  Hist Hist::AdoptWithErrors(Eigen::ArrayXd&& v, Eigen::ArrayXd&& sqerr)
   {
+    // Function to let user manually set fSumSq for a Hist.
     Hist ret;
     ret.fType = kDense;
     ret.fData = std::move(v);
-    ret.fSumSq = std::move(e);
+    ret.fSumSq = std::move(sqerr);
     return ret;
   }
   

--- a/CAFAna/Core/Hist.h
+++ b/CAFAna/Core/Hist.h
@@ -36,6 +36,7 @@ namespace ana
     static Hist AdoptSparse(Eigen::SparseVector<double>&& v);
     static Hist AdoptStan(Eigen::ArrayXstan&& v);
     static Hist Adopt(Eigen::ArrayXd&& v);
+    static Hist AdoptWithErrors(Eigen::ArrayXd&& v, Eigen::ArrayXd&& sqerr);
 
     static Hist FromDirectory(TDirectory* dir);
 

--- a/CAFAna/Core/Spectrum.cxx
+++ b/CAFAna/Core/Spectrum.cxx
@@ -50,6 +50,20 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  Spectrum::Spectrum(Eigen::ArrayXd&& h,
+		     Eigen::ArrayXd&& sqerr,
+		     const LabelsAndBins& axis,
+                     double pot, double livetime)
+    : fHist(Hist::AdoptWithErrors(std::move(h), std::move(sqerr))), fPOT(pot), fLivetime(livetime), fAxis(axis)
+  {
+    bool EnabledStats = (getenv("CAFANA_STAT_ERRS") != 0);
+    if (!EnabledStats) {
+      std::cout << "[ERROR]: Must have stat errors enabled to use this constructor." std::endl;
+      abort();
+    }
+  }
+	
+  //----------------------------------------------------------------------
   Spectrum::Spectrum(const Spectrum& rhs):
     fHist(rhs.fHist),
     fPOT(rhs.fPOT),

--- a/CAFAna/Core/Spectrum.h
+++ b/CAFAna/Core/Spectrum.h
@@ -83,7 +83,15 @@ namespace ana
     Spectrum(Eigen::ArrayXstan&& h,
              const LabelsAndBins& axis,
              double pot, double livetime);
-
+ 
+    /// Makes a spectrum from two eigen arrays
+    /// One array is for bin contents, the other for sq(errors)
+    /// Only to be used with stat errors enabled
+    Spectrum(Eigen::ArrayXd&& h,
+	     Eigen::ArrayXd&& sqerr,
+	     const LabelsAndBins& axis,
+	     double pot, double livetime);
+	  
     /// 2D Spectrum taking 2 HistAxis
     template<class T, class U>
     Spectrum(SpectrumLoaderBase& loader,


### PR DESCRIPTION
I have added an additional constructor for Spectrum which takes two array arguments. The extra one is for the SumSq array. I was unsure if I implemented the check for the CAFANA_STAT_ERRS environment variable correctly. The idea is that if you have not set CAFANA_STAT_ERRS in your setup then calling this constructor will throw an error and abort.