### PR TITLE
Make IFDHC optional again

### DIFF
--- a/CAFAna/Core/CMakeLists.txt
+++ b/CAFAna/Core/CMakeLists.txt
@@ -3,13 +3,20 @@ set(LIBRARY CAFAnaCoreExt)
 file(GLOB HEADER_FILES *.h *.txx)
 file(GLOB SOURCES *.cxx)
 
+if(NOT Ifdhc_FOUND)
+        list(FILTER HEADER_FILES EXCLUDE REGEX ".*SAM.*")
+        list(FILTER SOURCES EXCLUDE REGEX ".*SAM.*")
+endif()
+
 add_library(${LIBRARY} SHARED
         ${HEADER_FILES}
         ${SOURCES}
 )
 
 link_root(${LIBRARY})
-link_ifdhc(${LIBRARY})
+if(Ifdhc_FOUND)
+    link_ifdhc(${LIBRARY})
+endif()
 link_tbb(${LIBRARY})
 
 install(TARGETS ${LIBRARY} LIBRARY DESTINATION ${TARGET_LIBDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,11 @@ find_package(TBB REQUIRED)
 find_package(Threads REQUIRED)
 link_libraries(Threads::Threads)
 
-find_package(Ifdhc)
+if(NOT DEFINED NO_IFDHC OR NOT NO_IFDHC)
+    find_package(Ifdhc)
+else()
+    set(Ifdhc_FOUND FALSE)
+endif()
 
 # Record what flags were used. Can dump with
 # readelf -p .GCC.command.line libCAFAnaCoreExt.so 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,11 @@ set(CMAKE_CXX_FLAGS_MINSIZEREL "${common_flags} -Os")
 # NDEBUG needed to ensure assert() causes an abort() even in optimized builds
 set(CMAKE_CXX_FLAGS_RELEASE "${common_flags} -O2 -DNDEBUG -g")
 
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
+if(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}  -Wl,-undefined,error")
+elseif()
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")   
+endif()
 
 # ROOT does things differently depending on whether it's built for C++17 or not :-\
 string(REGEX REPLACE ".*c\\+\\+([0-9][0-9]).*" "\\1" ROOT_CXX_STANDARD ${ROOT_CXX_FLAGS})
@@ -92,6 +96,7 @@ include_directories(
         ${EIGEN_INC}
         ${BOOST_INC}
         ${SUNDIALS_INC}
+        ${TBB_INC}
 )
 
 if(Ifdhc_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(Threads REQUIRED)
 link_libraries(Threads::Threads)
 
 if(NOT DEFINED NO_IFDHC OR NOT NO_IFDHC)
-    find_package(Ifdhc)
+    find_package(Ifdhc REQUIRED)
 else()
     set(Ifdhc_FOUND FALSE)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,12 +25,12 @@ find_package(Eigen REQUIRED)
 find_package(Boost REQUIRED)
 find_package(Sundials REQUIRED)
 find_package(TBB REQUIRED)
-find_package(Ifdhc REQUIRED)
 
 # pthread / std::thread
 find_package(Threads REQUIRED)
 link_libraries(Threads::Threads)
 
+find_package(Ifdhc)
 
 # Record what flags were used. Can dump with
 # readelf -p .GCC.command.line libCAFAnaCoreExt.so 
@@ -92,8 +92,11 @@ include_directories(
         ${EIGEN_INC}
         ${BOOST_INC}
         ${SUNDIALS_INC}
-        ${IFDHC_INC}
 )
+
+if(Ifdhc_FOUND)
+    include_directories(${IFDHC_INC})
+endif()
 
 # by default make the bin/ and lib/ dirs in the top of the source dir.
 # can by overridden on command line if desired

--- a/cmake/Modules/FindTBB.cmake
+++ b/cmake/Modules/FindTBB.cmake
@@ -9,6 +9,10 @@ set(TBB_DIR $ENV{TBB_DIR})
 message(STATUS "Trying TBB directory: ${TBB_DIR}")
 
 set(TBB_VERSION $ENV{TBB_UPS_VERSION})
+if(NOT TBB_VERSION AND DEFINED ENV{TBB_VERSION})
+	set(TBB_VERSION $ENV{TBB_VERSION})
+endif()
+
 if(NOT TBB_VERSION)
 	if (EXISTS ${TBB_DIR}/ups/sundials.table)
 		file(READ ${TBB_DIR}/ups/sundials.table table_contents)


### PR DESCRIPTION
TBB_VERSION now checks ENV{TBB_VERSION} if ENV{TBB_UPS_VERSION} is not defined. IFDHC dependency is now optional