### PR TITLE
Allow user access to errors from Spectrum

### DIFF
--- a/CAFAna/Core/Hist.cxx
+++ b/CAFAna/Core/Hist.cxx
@@ -242,6 +242,18 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  const Eigen::ArrayXd& Hist::GetEigenSqErrors() const
+  {
+    assert(fType == kDense);
+    if(fSqrtErrs){
+      // Need to make the errors real, not just implicit
+      fSumSq = fData.sqrt();
+      fSqrtErrs = false;
+    }
+    return fSumSq;
+  }
+
+  //----------------------------------------------------------------------
   int Hist::GetNbinsX() const
   {
     assert(Initialized());

--- a/CAFAna/Core/Hist.h
+++ b/CAFAna/Core/Hist.h
@@ -45,7 +45,15 @@ namespace ana
     bool HasStan() const {return fType == kDenseStan;}
     const Eigen::ArrayXd& GetEigen() const {assert(fType == kDense); return fData;}
     const Eigen::ArrayXstan& GetEigenStan() const {assert(fType == kDenseStan); return fDataStan;}
-    const Eigen::ArrayXd& GetEigenSqErrors() const {assert(fType == kDense); return fSumSq;}
+    const Eigen::ArrayXd& GetEigenSqErrors() const {
+      assert(fType == kDense);
+      if (fSqrtErrs) {
+        fSumSq = fData.sqrt();
+        return fSumSq;
+      } else {
+        return fSumSq;
+      }
+    }
 
     int GetNbinsX() const;
     double GetBinError(int i) const;

--- a/CAFAna/Core/Hist.h
+++ b/CAFAna/Core/Hist.h
@@ -45,7 +45,7 @@ namespace ana
     bool HasStan() const {return fType == kDenseStan;}
     const Eigen::ArrayXd& GetEigen() const {assert(fType == kDense); return fData;}
     const Eigen::ArrayXstan& GetEigenStan() const {assert(fType == kDenseStan); return fDataStan;}
-    const Eigen::ArrayXd& GetEigenSqError() const {assert(fType == kDense); return fSumSq;}
+    const Eigen::ArrayXd& GetEigenSqErrors() const {assert(fType == kDense); return fSumSq;}
 
     int GetNbinsX() const;
     double GetBinError(int i) const;

--- a/CAFAna/Core/Hist.h
+++ b/CAFAna/Core/Hist.h
@@ -45,6 +45,7 @@ namespace ana
     bool HasStan() const {return fType == kDenseStan;}
     const Eigen::ArrayXd& GetEigen() const {assert(fType == kDense); return fData;}
     const Eigen::ArrayXstan& GetEigenStan() const {assert(fType == kDenseStan); return fDataStan;}
+    const Eigen::ArrayXd& GetEigenSqError() const {assert(fType == kDense); return fSumSq;}
 
     int GetNbinsX() const;
     double GetBinError(int i) const;

--- a/CAFAna/Core/Hist.h
+++ b/CAFAna/Core/Hist.h
@@ -47,12 +47,12 @@ namespace ana
     const Eigen::ArrayXstan& GetEigenStan() const {assert(fType == kDenseStan); return fDataStan;}
     const Eigen::ArrayXd& GetEigenSqErrors() const {
       assert(fType == kDense);
-      if (fSqrtErrs) {
+      if(fSqrtErrs){
         fSumSq = fData.sqrt();
-        return fSumSq;
-      } else {
-        return fSumSq;
+        fSqrtErrs = false;
       }
+      return fSumSq;
+    }
     }
 
     int GetNbinsX() const;

--- a/CAFAna/Core/Hist.h
+++ b/CAFAna/Core/Hist.h
@@ -45,15 +45,7 @@ namespace ana
     bool HasStan() const {return fType == kDenseStan;}
     const Eigen::ArrayXd& GetEigen() const {assert(fType == kDense); return fData;}
     const Eigen::ArrayXstan& GetEigenStan() const {assert(fType == kDenseStan); return fDataStan;}
-    const Eigen::ArrayXd& GetEigenSqErrors() const
-    {
-      assert(fType == kDense);
-      if(fSqrtErrs){
-        fSumSq = fData.sqrt();
-        fSqrtErrs = false;
-      }
-      return fSumSq;
-    }
+    const Eigen::ArrayXd& GetEigenSqErrors() const;
 
     int GetNbinsX() const;
     double GetBinError(int i) const;

--- a/CAFAna/Core/Hist.h
+++ b/CAFAna/Core/Hist.h
@@ -45,14 +45,14 @@ namespace ana
     bool HasStan() const {return fType == kDenseStan;}
     const Eigen::ArrayXd& GetEigen() const {assert(fType == kDense); return fData;}
     const Eigen::ArrayXstan& GetEigenStan() const {assert(fType == kDenseStan); return fDataStan;}
-    const Eigen::ArrayXd& GetEigenSqErrors() const {
+    const Eigen::ArrayXd& GetEigenSqErrors() const
+    {
       assert(fType == kDense);
       if(fSqrtErrs){
         fSumSq = fData.sqrt();
         fSqrtErrs = false;
       }
       return fSumSq;
-    }
     }
 
     int GetNbinsX() const;

--- a/CAFAna/Core/Spectrum.cxx
+++ b/CAFAna/Core/Spectrum.cxx
@@ -273,9 +273,9 @@ namespace ana
   Eigen::ArrayXd Spectrum::GetEigenSqErrors(double exposure, EExposureType expotype) const
   {
     if(expotype == kPOT)
-      return std::pow(exposure/fPOT, 2) * fHist.GetEigenSqErrors();
+      return util::sqr(exposure/fPOT) * fHist.GetEigenSqErrors();
     else
-      return std::pow(exposure/fLivetime, 2) * fHist.GetEigenSqErrors();
+      return util::sqr(exposure/fLivetime) * fHist.GetEigenSqErrors();
   }
 
   //----------------------------------------------------------------------

--- a/CAFAna/Core/Spectrum.cxx
+++ b/CAFAna/Core/Spectrum.cxx
@@ -270,6 +270,15 @@ namespace ana
   }
 
   //----------------------------------------------------------------------
+  Eigen::ArrayXd Spectrum::GetEigenSqErrors(double exposure, EExposureType expotype) const
+  {
+    if(expotype == kPOT)
+      return std::pow(exposure/fPOT, 2) * fHist.GetEigenSqErrors();
+    else
+      return std::pow(exposure/fLivetime, 2) * fHist.GetEigenSqErrors();
+  }
+
+  //----------------------------------------------------------------------
   void Spectrum::Scale(double c)
   {
     fHist.Scale(c);

--- a/CAFAna/Core/Spectrum.h
+++ b/CAFAna/Core/Spectrum.h
@@ -187,9 +187,11 @@ namespace ana
     /// NB these don't have POT scaling. For expert high performance ops only!
     const Eigen::ArrayXd& GetEigen() const {return fHist.GetEigen();}
     const Eigen::ArrayXstan& GetEigenStan() const {return fHist.GetEigenStan();}
+    const Eigen::ArrayXd& GetEigenSqErrors() const {return fHist.GetEigenSqErrors();}
 
     Eigen::ArrayXd GetEigen(double exposure, EExposureType expotype = kPOT) const;
     Eigen::ArrayXstan GetEigenStan(double exposure, EExposureType expotype = kPOT) const;
+    Eigen::ArrayXd GetEigenSqErrors(double exposure, EExposureType expotype = kPOT) const;
 
     /// \brief Return total number of events scaled to \a pot
     ///


### PR DESCRIPTION
Adds new functions to Hist and Spectrum classes. These allow the user to directly access the errors from Spectrum without having to plot a ROOT histogram.