### PR TITLE
update cmake build for spack

### DIFF
--- a/CAFAna/Core/LabelsAndBins.h
+++ b/CAFAna/Core/LabelsAndBins.h
@@ -2,6 +2,7 @@
 
 #include "CAFAna/Core/Binning.h"
 
+#include <optional>
 #include <string>
 
 namespace ana

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,14 +17,28 @@ endif()
 execute_process(COMMAND git describe --tags OUTPUT_VARIABLE CAFANACORE_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCAFANACORE_VERSION=\\\"${CAFANACORE_VERSION}\\\"")
 
+option (SPACK "Building through Spack")
 
 # non-negotiable dependencies
-find_package(ROOT REQUIRED)
-find_package(StanMath REQUIRED)
-find_package(Eigen REQUIRED)
-find_package(Boost REQUIRED)
-find_package(Sundials REQUIRED)
-find_package(TBB REQUIRED)
+if (SPACK)
+    find_package(ROOT REQUIRED CONFIG)
+    find_package(Eigen3 REQUIRED CONFIG)
+    find_package(Boost REQUIRED CONFIG)
+    find_package(SUNDIALS REQUIRED CONFIG)
+    find_package(TBB REQUIRED CONFIG)
+
+    function(link_tbb target)
+        target_link_libraries(${target} PUBLIC TBB::tbb)
+    endfunction()
+else()
+    find_package(ROOT REQUIRED MODULE)
+    find_package(Eigen REQUIRED MODULE)
+    find_package(Boost REQUIRED MODULE)
+    find_package(Sundials REQUIRED MODULE)
+    find_package(TBB REQUIRED MODULE)
+endif()
+
+find_package(StanMath REQUIRED MODULE)
 
 # pthread / std::thread
 find_package(Threads REQUIRED)


### PR DESCRIPTION
reduce cmake build's dependence on UPS environment variables. most of the dependencies we pull in via spack have CMake config files already baked in, so we don't need to depend on this repo's CMake module files as heavily.

this PR also includes a header that appeared to be missing from one of the header files. as far as i can tell, this is unrelated to the build system – we just need to `#include <optional>` before defining an `std::optional` type.