### PR TITLE
Potpourri

### DIFF
--- a/CAFAna/Core/Cut.h
+++ b/CAFAna/Core/Cut.h
@@ -78,11 +78,13 @@ namespace ana
     _Cut(const _Cut&) = default;
     _Cut(_Cut&&) = default;
 
-    // Convert from cuts without spillT to those with a typed spillT but null
-    // function pointer
-    _Cut(const _Cut<RecT, void>& c) : CutBase(c)
-    {
-    }
+//  disabled until we discover what the intent was here,
+//  since it appears to interfere with the (templated) copy constructor
+//    // Convert from cuts without spillT to those with a typed spillT but null
+//    // function pointer
+//    _Cut(const _Cut<RecT, void>& c) : CutBase(c)
+//    {
+//    }
 
     _Cut& operator=(const _Cut& c) = default;
     _Cut& operator=(_Cut&& c) = default;

--- a/CAFAna/Core/WildcardSource.cxx
+++ b/CAFAna/Core/WildcardSource.cxx
@@ -6,8 +6,13 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <cstring>
+#include <string.h>
 #include <unistd.h>
+#include <libgen.h>
 #include <iostream>
+
+#include "ifdh.h"
 
 namespace
 {
@@ -45,9 +50,19 @@ namespace ana
     // If we found nothing, it may be because pnfs isn't mounted.
     if(ret.empty() &&
        wildcard.find("/pnfs/") == 0 &&
-       stat("/pnfs/", &ss) != 0){
+       stat("/pnfs/", &ss) != 0)
+    {
+      // IFDH queries can be expensive, leave the option to turn it off
+      if (getenv("CAFANA_DISABLE_IFDH"))
+        std::cout << "No files matching " << wildcard << " but that's probably because /pnfs is not mounted on the current grid node. If you have to use your own files, either try running it interactivly or try sam_add_dataset to create one." << std::endl;
+      else
+      {
+        static ifdh_ns::ifdh ifdh = ifdh_ns::ifdh();
 
-      std::cout << "No files matching " << wildcard << " but that's probably because /pnfs is not mounted on the current grid node. If you have to use your own files, either try running it interactivly or try sam_add_dataset to create one." << std::endl;
+        char * path = strdup(wildcard.c_str());
+        std::vector<ifdh_ns::ifdh_lss_pair> finfos = ifdh.findMatchingFiles(dirname(path), basename(path));
+        std::transform(finfos.begin(), finfos.end(), std::back_inserter(ret), [](const ifdh_ns::ifdh_lss_pair& p) { return p.first; });
+      }
     }
 
     return ret;


### PR DESCRIPTION
A few sundry fixes:
* disable a copy conversion operator that's interfering with a copy constructor
* use `unique_ptr`s instead of hand-rolling memory management
* improve (?) searches for files via PNFS with IFDH

None of these should impact any users of CAFAnaCore `v1`, I don't think.