### PR TITLE
Enable stan threading with a new UPS product via STAN=stanthread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ endif()
 
 # make Stan dependency optional, but use it by default
 option(CAFANACORE_USE_STAN "Build against Stan?" True)
+option(USE_STAN_THREADS "Use threading with Stan?" True)
 if(CAFANACORE_USE_STAN)
     add_compile_definitions(CAFANACORE_USE_STAN)
 endif()
@@ -64,6 +65,10 @@ else()
         find_package(Sundials REQUIRED MODULE)
         find_package(TBB REQUIRED MODULE)
     endif()
+endif()
+
+if(USE_STAN_THREADS)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSTAN_THREADS")
 endif()
 
 if (CAFANACORE_USE_STAN)

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,10 @@
 CMAKE_BUILD_TYPE ?= Release
 CMAKE_CXX_COMPILER ?= g++
 CAFANACORE_USE_STAN ?= On
+USE_STAN_THREADS ?= Off
 
 all:
-	if [ ! -e build ]; then mkdir -p build; cd build; cmake -GNinja .. -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) -DCMAKE_CXX_COMPILER=$(CMAKE_CXX_COMPILER) -DCAFANACORE_USE_STAN=$(CAFANACORE_USE_STAN); fi
+	if [ ! -e build ]; then mkdir -p build; cd build; cmake -GNinja .. -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) -DCMAKE_CXX_COMPILER=$(CMAKE_CXX_COMPILER) -DCAFANACORE_USE_STAN=$(CAFANACORE_USE_STAN); -DUSE_STAN_THREADS=$(USE_STAN_THREADS); fi
 	ninja -C build -j`nproc --all` install
 
 clean:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ make install
 ## How to build and and test your changes locally
 
 - `export QUALIFIER=e26:prof` or `e26:debug`, etc
-- `export STAN=stan` or `stanfree`
+- `export STAN=stan` or `stanfree` or `stanthread`
 - `jenkins/jenkins_build.sh` (or paste parts of it into your terminal)
 - set `CAFANACORE_LIB` and `CAFANACORE_INC` manually to point to what you just built
 - rebuild your test release

--- a/jenkins/dependencies.sh
+++ b/jenkins/dependencies.sh
@@ -14,7 +14,18 @@ if [[ $QUAL == *:n311* ]]; then NQUAL=n311; QUAL=${QUAL/:n311/}; fi
 if [[ $QUAL == *:n319* ]]; then NQUAL=n319; QUAL=${QUAL/:n319/}; fi
 
 WANTSTAN=yes
-if [[ $QUAL == *:stanfree ]]; then WANTSTAN=no; QUAL=${QUAL}/:stanfree/}; else QUAL=${QUAL/:stan/}; fi
+if [[ $QUAL == *:stanfree ]]
+then
+  WANTSTAN=no
+  QUAL=${QUAL/:stanfree/}
+else
+  if [[ $QUAL == *:stanthread ]]
+  then
+    QUAL=${QUAL/:stanthread/}
+  else
+    QUAL=${QUAL/:stan/}
+  fi
+fi
 
 if [[ $NQUAL == n311 ]]
 then

--- a/jenkins/jenkins_build.sh
+++ b/jenkins/jenkins_build.sh
@@ -23,7 +23,7 @@ fi
 
 if [[ x$STAN != *stan* ]]
 then
-    echo Must specify stan or stanfree in STAN variable $STAN
+    echo Must specify stan or stanfree or stanthread in STAN variable $STAN
     exit 1
 fi
 
@@ -57,11 +57,18 @@ else
     FLAGS=$FLAGS' CMAKE_CXX_COMPILER=g++' || exit 2
 fi
 
-if [[ $STAN == "stan" ]]
+if [[ $STAN == "stan" || $STAN == "stanthread" ]]
 then 
     FLAGS=$FLAGS' CAFANACORE_USE_STAN=On' || exit 2
 else
     FLAGS=$FLAGS' CAFANACORE_USE_STAN=Off' || exit 2
+fi
+
+if [[ $STAN == "stanthread" ]]
+then
+    FLAGS=$FLAGS' USE_STAN_THREADS=On' || exit 2
+else
+    FLAGS=$FLAGS' USE_STAN_THREADS=Off' || exit 2
 fi
 
 time make $FLAGS || exit 2

--- a/jenkins/make_table.sh
+++ b/jenkins/make_table.sh
@@ -14,7 +14,7 @@ do
     do
         for COMPILER in e26 c14
         do
-	    for STAN in stan stanfree
+	    for STAN in stan stanfree stanthread
 	    do
 		echo FLAVOR=ANY
 		echo QUALIFIERS=\"${OPT}:${COMPILER}:${EXPT}:${STAN}\"


### PR DESCRIPTION
This is exactly the same idea to [OscLib PR #34](https://github.com/cafana/OscLib/pull/34). The compiler flag change works as I expect when I deploy it as a local UPS product, but I have no way to test my edits to the jenkins infrastructure.